### PR TITLE
Add `overlay` widget to header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.0.6]
+
+Add `overlay` widget to header.
+This widget will be placed on top the header container.
+
+Can be used to add clickable items to the header bottom which doesn't prevent it from scrolling.
+
 ## [1.0.5]
 
 * Get rid of nested ListViews, allow list items to consume gestures [Thanks PiN73].

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Sample 1
 Sample 2
 
 <p align="center">
+  <!-- TODO update gif to show icon in `overlay` -->
   <img width="300" height="600" src="https://media.giphy.com/media/f9SzoZKqo1vfdlCaT5/giphy.gif">
 </p>
 
@@ -28,7 +29,7 @@ Sample 3
 You should ensure that you add the router as a dependency in your flutter project.
 ```yaml
 dependencies:
-  stretchy_header: "^1.0.5"
+  stretchy_header: "^1.0.6"
 ```
 
 You should then run `flutter packages upgrade` or update your packages in IntelliJ.
@@ -98,6 +99,28 @@ class SampleCustomHeader extends StatelessWidget {
               child: Text("DV"),
             ),
             margin: EdgeInsets.zero,
+          ),
+          overlay: Align(
+            alignment: Alignment.bottomRight,
+            child: Material(
+              color: Colors.transparent,
+              child: InkResponse(
+                onTap: () {
+                  Scaffold.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text('onTap'),
+                    ),
+                  );
+                },
+                child: Padding(
+                  padding: EdgeInsets.all(12),
+                  child: Icon(
+                    Icons.fullscreen,
+                    color: Colors.white,
+                  ),
+                ),
+              ),
+            ),
           ),
         ),
         child: Padding(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -117,6 +117,28 @@ class SampleCustomHeader extends StatelessWidget {
             ),
             margin: EdgeInsets.zero,
           ),
+          overlay: Align(
+            alignment: Alignment.bottomRight,
+            child: Material(
+              color: Colors.transparent,
+              child: InkResponse(
+                onTap: () {
+                  Scaffold.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text('onTap'),
+                    ),
+                  );
+                },
+                child: Padding(
+                  padding: EdgeInsets.all(12),
+                  child: Icon(
+                    Icons.fullscreen,
+                    color: Colors.white,
+                  ),
+                ),
+              ),
+            ),
+          ),
         ),
         child: Padding(
           padding: const EdgeInsets.all(15),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -113,7 +113,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.5"
+    version: "1.0.6"
   string_scanner:
     dependency: transitive
     description:

--- a/lib/stretchy_header.dart
+++ b/lib/stretchy_header.dart
@@ -122,6 +122,35 @@ class HeaderData {
   ///alignment for the highlight header
   final HighlightHeaderAlignment highlightHeaderAlignment;
 
+  ///This widget will be placed on top the header container.
+  ///Can be used to add clickable items to the header bottom
+  ///which doesn't prevent it from scrolling.
+  ///
+  ///For example:
+  ///overlay: Align(
+  //  alignment: Alignment.bottomRight,
+  //  child: Material(
+  //    color: Colors.transparent,
+  //    child: InkResponse(
+  //      onTap: () {
+  //        Scaffold.of(context).showSnackBar(
+  //          SnackBar(
+  //            content: Text('onTap'),
+  //          ),
+  //        );
+  //      },
+  //      child: Padding(
+  //        padding: EdgeInsets.all(12),
+  //        child: Icon(
+  //          Icons.fullscreen,
+  //          color: Colors.white,
+  //        ),
+  //      ),
+  //    ),
+  //  ),
+  //)
+  final Widget overlay;
+
   ///The color of the blur, white by default
   final Color blurColor;
 
@@ -137,6 +166,7 @@ class HeaderData {
     this.highlightHeader,
     this.blurContent = true,
     this.highlightHeaderAlignment = HighlightHeaderAlignment.bottom,
+    this.overlay,
     this.blurColor,
     this.backgroundColor,
   })  : assert(header != null),
@@ -262,7 +292,10 @@ class _StretchyHeaderBaseState extends State<StretchyHeaderBase> {
               _scrollController,
               EdgeInsets.zero,
               BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics()),
-              SizedBox(height: _headerSize),
+              SizedBox(
+                height: _headerSize,
+                child: widget.headerData.overlay,
+              ),
             ),
           ),
           widget.headerData.highlightHeader != null

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stretchy_header
 description: This package allows us to create a elastic header, to give a good effect when you scroll down the widget.
-version: 1.0.5
+version: 1.0.6
 author: Diego Velásquez <diegoveloper@gmail.com>
 homepage: https://github.com/diegoveloper/flutter_stretchy_header/
 


### PR DESCRIPTION
This widget will be placed on top the header container.
Can be used to add clickable items to the header bottom which doesn't prevent it from scrolling.